### PR TITLE
Add data ingestion module with ORM models

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,14 @@
-# thoughtful
+# Thoughtful
+
+This repository contains a simple data ingestion example using SQLAlchemy and
+WebSocket/REST clients.
+
+## Data Ingestion
+
+The `data` package exposes a `ProviderClient` capable of:
+
+- Connecting to a WebSocket for streaming underlying price ticks.
+- Querying a REST endpoint for option chain data.
+- Persisting the received information into SQLite or PostgreSQL via SQLAlchemy.
+
+See `data/ingestion.py` for an example entrypoint.

--- a/data/__init__.py
+++ b/data/__init__.py
@@ -1,0 +1,13 @@
+"""Data ingestion package for market data."""
+
+from .database import SessionLocal, init_db
+from .ingestion import ProviderClient
+from .models import OptionContract, UnderlyingPrice
+
+__all__ = [
+    "SessionLocal",
+    "init_db",
+    "ProviderClient",
+    "UnderlyingPrice",
+    "OptionContract",
+]

--- a/data/database.py
+++ b/data/database.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+import os
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+DATABASE_URL = os.getenv("DATABASE_URL", "sqlite:///market_data.db")
+
+engine = create_engine(
+    DATABASE_URL,
+    connect_args={"check_same_thread": False}
+    if DATABASE_URL.startswith("sqlite")
+    else {},
+)
+SessionLocal = sessionmaker(bind=engine)
+
+
+def init_db() -> None:
+    from .models import Base
+
+    Base.metadata.create_all(bind=engine)

--- a/data/ingestion.py
+++ b/data/ingestion.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import asyncio
+import json
+from datetime import datetime, date
+from typing import Iterable
+
+import requests
+import websockets
+from sqlalchemy.orm import Session
+
+from .database import SessionLocal, init_db
+from .models import OptionContract, UnderlyingPrice
+
+
+class ProviderClient:
+    """Simple client for a market data provider."""
+
+    def __init__(self, websocket_url: str, rest_url: str) -> None:
+        self.websocket_url = websocket_url
+        self.rest_url = rest_url.rstrip("/")
+
+    async def subscribe_ticks(self, symbols: Iterable[str], session: Session) -> None:
+        """Connect to provider WebSocket and store incoming ticks."""
+        async with websockets.connect(self.websocket_url) as ws:
+            await ws.send(json.dumps({"type": "subscribe", "symbols": list(symbols)}))
+            async for msg in ws:
+                data = json.loads(msg)
+                tick = UnderlyingPrice(
+                    symbol=data["symbol"],
+                    price=float(data["price"]),
+                    timestamp=datetime.fromisoformat(data["timestamp"]),
+                )
+                session.add(tick)
+                session.commit()
+
+    def fetch_option_chain(self, symbol: str, session: Session) -> None:
+        """Fetch option chain for *symbol* via REST and store contracts."""
+        url = f"{self.rest_url}/options/{symbol}"
+        response = requests.get(url, timeout=10)
+        response.raise_for_status()
+        contracts = response.json()
+        for item in contracts:
+            contract = OptionContract(
+                symbol=symbol,
+                expiration=date.fromisoformat(item["expiration"]),
+                strike=float(item["strike"]),
+                option_type=item["type"],
+                bid=item.get("bid"),
+                ask=item.get("ask"),
+            )
+            session.add(contract)
+        session.commit()
+
+
+def main() -> None:
+    """Example entrypoint for running the ingestion pipeline."""
+    init_db()
+    session = SessionLocal()
+    client = ProviderClient(
+        websocket_url="wss://example.com/marketdata",
+        rest_url="https://example.com/api",
+    )
+    # In production, you would likely run subscribe_ticks in a background task.
+    symbols = ["AAPL"]
+    asyncio.run(client.subscribe_ticks(symbols, session))
+    client.fetch_option_chain("AAPL", session)
+
+
+if __name__ == "__main__":  # pragma: no cover - manual execution
+    main()

--- a/data/models.py
+++ b/data/models.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from datetime import datetime, date
+from typing import Optional
+
+from sqlalchemy import Column, Date, DateTime, Float, Integer, String
+from sqlalchemy.orm import declarative_base
+
+Base = declarative_base()
+
+
+class UnderlyingPrice(Base):
+    __tablename__ = "underlying_prices"
+
+    id: int = Column(Integer, primary_key=True)
+    symbol: str = Column(String, index=True, nullable=False)
+    price: float = Column(Float, nullable=False)
+    timestamp: datetime = Column(DateTime, default=datetime.utcnow, nullable=False)
+
+
+class OptionContract(Base):
+    __tablename__ = "option_contracts"
+
+    id: int = Column(Integer, primary_key=True)
+    symbol: str = Column(String, index=True, nullable=False)
+    expiration: date = Column(Date, nullable=False)
+    strike: float = Column(Float, nullable=False)
+    option_type: str = Column(String(4), nullable=False)  # 'call' or 'put'
+    bid: Optional[float] = Column(Float)
+    ask: Optional[float] = Column(Float)
+    timestamp: datetime = Column(DateTime, default=datetime.utcnow, nullable=False)


### PR DESCRIPTION
## Summary
- add SQLAlchemy models for underlying prices and option contracts
- implement provider client to stream ticks and fetch option chains
- document ingestion usage

## Testing
- `pip install SQLAlchemy websockets requests` *(failed: Tunnel connection failed: 403 Forbidden)*
- `pytest`
- `ruff check data`


------
https://chatgpt.com/codex/tasks/task_e_68b9e188fd34833285fa6eb2f2e06d5e