### PR TITLE
Add FastAPI service with nohup runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,15 @@
 # thoughtful
+
+Simple FastAPI application with `/health` and `/trigger` endpoints.
+
+## Running with nohup
+
+1. Install dependencies:
+   ```bash
+   pip install fastapi uvicorn
+   ```
+2. Start the server in the background:
+   ```bash
+   ./run_nohup.sh
+   ```
+   The process ID is stored in `app.pid` and output is logged to `app.log`.

--- a/main.py
+++ b/main.py
@@ -1,0 +1,17 @@
+from fastapi import FastAPI
+import uvicorn
+
+app = FastAPI()
+
+@app.get('/health')
+def health() -> dict:
+    """Health check endpoint"""
+    return {'status': 'ok'}
+
+@app.post('/trigger')
+def trigger() -> dict:
+    """Trigger action endpoint"""
+    return {'message': 'triggered'}
+
+if __name__ == '__main__':
+    uvicorn.run('main:app', host='0.0.0.0', port=8000)

--- a/run_nohup.sh
+++ b/run_nohup.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+# Run the FastAPI app using nohup for persistence
+nohup uvicorn main:app --host 0.0.0.0 --port 8000 > app.log 2>&1 &
+echo $! > app.pid


### PR DESCRIPTION
## Summary
- Implement basic FastAPI app with `/health` and `/trigger` routes
- Provide `run_nohup.sh` script to keep the service running in the background
- Document setup and nohup usage in README

## Testing
- `python -m py_compile main.py`
- `bash -n run_nohup.sh`


------
https://chatgpt.com/codex/tasks/task_e_68b9e18f67188332be31ff7f9a507413